### PR TITLE
Configure Specific AI Gateway and Model instead of direct model providers 

### DIFF
--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -31,4 +31,8 @@ model_config:
 
 3. Define the agent
 
+Follow the steps in [Guide to Build a new deepwork agent](./GUIDE_BUILD_NEW_DEEPWORK_AGENT.md) for defining an agent.
+
 4. Run the agent
+
+Follow the steps in [Guide to Build a new deepwork agent](./GUIDE_BUILD_NEW_DEEPWORK_AGENT.md) for running an agent that uses the AI Gateway.

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -1,0 +1,4 @@
+# Cookbook
+
+## Build an Agent to connect to Internal AI Gateways
+

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -1,4 +1,34 @@
 # Cookbook
 
-## Build an Agent to connect to Internal AI Gateways
+## Build an Agent to connect to AI Gateways, internal or otherwise
 
+This guide shows how to configure an agent to connect to an AI Gateway, instead of directly to model providers.
+
+1. Configure the environment variables required for the AI Gateway
+```bash
+export GATEWAY_AUTH_TOKEN="your-auth-token"
+export GATEWAY_USER_ID="your-user-id"
+# any other params that are required for the AI Gateway
+```
+
+2. Configure the agent to use the AI Gateway by specifying the header keys and env variables to get values for these keys
+
+```yaml
+model_config:
+  - provider: "gateway"
+    model: "gpt-5"
+    base_url: "https://your-ai-gateway-url"
+    header_keys:
+      - "X-Gateway-Auth-Token"
+      - "X-Gateway-User-Id"
+      - "X-Gateway-Param-1"
+    header_values_env_keys:
+      - "GATEWAY_AUTH_TOKEN"
+      - "GATEWAY_USER_ID"
+      - "GATEWAY_PARAM_1"
+    enabled: true
+```
+
+3. Define the agent
+
+4. Run the agent

--- a/opus_agent_base/src/opus_agent_base/gateway/openai_compatible_gateway.py
+++ b/opus_agent_base/src/opus_agent_base/gateway/openai_compatible_gateway.py
@@ -8,28 +8,41 @@ class AsyncOpenAIAIGatewayClient(AsyncOpenAI):
     """OpenAI client for AIGateway."""
 
     def _prepare_request(self, request):
-        headers_config = zip(self.header_keys, self.header_values_env_keys)
-        headers = {key: os.getenv(env_val) for key, env_val in headers_config if os.getenv(env_val)}
+        headers_config = zip(self.header_keys, self.header_values_env_keys, strict=True)
+        headers = {
+            key: os.getenv(env_val)
+            for key, env_val in headers_config
+            if os.getenv(env_val)
+        }
         request.headers.update(headers)
         return super()._prepare_request(request)
 
-    def configure_headers(self, header_keys: list[str], header_values_env_keys: list[str]):
+    def configure_headers(
+        self, header_keys: list[str], header_values_env_keys: list[str]
+    ):
         self.header_keys = header_keys
         self.header_values_env_keys = header_values_env_keys
 
+
 class OpenAIAIGatewayProvider(OpenAIProvider):
     def __init__(self, model_config: dict[str, str], *args, **kwargs):
-        super().__init__(api_key="NA", *args, **kwargs)
-        self.client = self._build_openai_compatible_client(model_config)
-        self._configure_openai_compatible_client(self.client, model_config)
+        client = self._build_openai_compatible_client(model_config)
+        super().__init__(*args, openai_client=client, **kwargs)
+        self._configure_openai_compatible_client(client, model_config)
 
     def _build_openai_compatible_client(self, model_config: dict[str, str]):
         base_url = model_config.get("base_url")
         timeout = int(model_config.get("timeout", 300))
-        client = AsyncOpenAIAIGatewayClient(version="v1", base_url=base_url + "/v1/openai/v1", api_key="NA", timeout=timeout)
+        client = AsyncOpenAIAIGatewayClient(
+            base_url=base_url + "/v1/openai/v1",
+            api_key="NA",
+            timeout=timeout,
+        )
         return client
 
-    def _configure_openai_compatible_client(self, client: AsyncOpenAIAIGatewayClient, model_config: dict[str, str]):
+    def _configure_openai_compatible_client(
+        self, client: AsyncOpenAIAIGatewayClient, model_config: dict[str, str]
+    ):
         header_keys = model_config.get("header_keys", [])
         header_values_env_keys = model_config.get("header_values_env_keys", [])
-        self._client.configure_headers(header_keys, header_values_env_keys)
+        client.configure_headers(header_keys, header_values_env_keys)

--- a/opus_agent_base/src/opus_agent_base/gateway/openai_compatible_gateway.py
+++ b/opus_agent_base/src/opus_agent_base/gateway/openai_compatible_gateway.py
@@ -1,0 +1,35 @@
+import os
+
+from openai import AsyncOpenAI
+from pydantic_ai.providers.openai import OpenAIProvider
+
+
+class AsyncOpenAIAIGatewayClient(AsyncOpenAI):
+    """OpenAI client for AIGateway."""
+
+    def _prepare_request(self, request):
+        headers_config = zip(self.header_keys, self.header_values_env_keys)
+        headers = {key: os.getenv(env_val) for key, env_val in headers_config if os.getenv(env_val)}
+        request.headers.update(headers)
+        return super()._prepare_request(request)
+
+    def configure_headers(self, header_keys: list[str], header_values_env_keys: list[str]):
+        self.header_keys = header_keys
+        self.header_values_env_keys = header_values_env_keys
+
+class OpenAIAIGatewayProvider(OpenAIProvider):
+    def __init__(self, model_config: dict[str, str], *args, **kwargs):
+        super().__init__(api_key="NA", *args, **kwargs)
+        self.client = self._build_openai_compatible_client(model_config)
+        self._configure_openai_compatible_client(self.client, model_config)
+
+    def _build_openai_compatible_client(self, model_config: dict[str, str]):
+        base_url = model_config.get("base_url")
+        timeout = int(model_config.get("timeout", 300))
+        client = AsyncOpenAIAIGatewayClient(version="v1", base_url=base_url + "/v1/openai/v1", api_key="NA", timeout=timeout)
+        return client
+
+    def _configure_openai_compatible_client(self, client: AsyncOpenAIAIGatewayClient, model_config: dict[str, str]):
+        header_keys = model_config.get("header_keys", [])
+        header_values_env_keys = model_config.get("header_values_env_keys", [])
+        self._client.configure_headers(header_keys, header_values_env_keys)

--- a/opus_agent_base/src/opus_agent_base/gateway/openai_compatible_gateway.py
+++ b/opus_agent_base/src/opus_agent_base/gateway/openai_compatible_gateway.py
@@ -25,6 +25,9 @@ class AsyncOpenAIAIGatewayClient(AsyncOpenAI):
 
 
 class OpenAIAIGatewayProvider(OpenAIProvider):
+    """
+    Provider for OpenAI compatible AI Gateways
+    """
     def __init__(self, model_config: dict[str, str], *args, **kwargs):
         client = self._build_openai_compatible_client(model_config)
         super().__init__(*args, openai_client=client, **kwargs)

--- a/opus_agent_base/src/opus_agent_base/model/model_manager.py
+++ b/opus_agent_base/src/opus_agent_base/model/model_manager.py
@@ -31,6 +31,7 @@ class ModelManager:
         self.initialize_anthropic_model()
         self.initialize_bedrock_model()
         self.initialize_ollama_model()
+        self.initialize_ai_gateway_model()
         logger.info("Model initialized")
 
     def get_enabled_models(self):

--- a/opus_agent_base/src/opus_agent_base/model/model_manager.py
+++ b/opus_agent_base/src/opus_agent_base/model/model_manager.py
@@ -78,6 +78,6 @@ class ModelManager:
             if model_config["provider"] == "gateway" and model_config["enabled"]:
                 self.model = OpenAIChatModel(
                     model_name=model_config["model"],
-                    provider=OpenAIAIGatewayProvider(model_config=model_config),
+                    provider=OpenAIAIGatewayProvider(model_config),
                 )
                 logger.info(f"AI Gateway model initialized: {model_config['model']}")

--- a/opus_agent_base/src/opus_agent_base/model/model_manager.py
+++ b/opus_agent_base/src/opus_agent_base/model/model_manager.py
@@ -8,6 +8,7 @@ from pydantic_ai.providers.ollama import OllamaProvider
 from pydantic_ai.providers.openai import OpenAIProvider
 
 from opus_agent_base.common.logging_config import console_log
+from opus_agent_base.gateway.openai_compatible_gateway import OpenAIAIGatewayProvider
 
 logger = logging.getLogger(__name__)
 
@@ -70,3 +71,12 @@ class ModelManager:
                     provider=OllamaProvider(base_url=model_config["base_url"]),
                 )
                 logger.info(f"Ollama/OpenAI model initialized: {model_config['model']}")
+
+    def initialize_ai_gateway_model(self):
+        for model_config in self.models_config:
+            if model_config["provider"] == "gateway" and model_config["enabled"]:
+                self.model = OpenAIChatModel(
+                    model_name=model_config["model"],
+                    provider=OpenAIAIGatewayProvider(model_config=model_config),
+                )
+                logger.info(f"AI Gateway model initialized: {model_config['model']}")


### PR DESCRIPTION
Solved for Issue #6 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an OpenAI-compatible AI Gateway client/provider and wires it into the model manager, with a cookbook detailing gateway configuration.
> 
> - **Backend**:
>   - **AI Gateway Support**:
>     - Add `AsyncOpenAIAIGatewayClient` to inject custom headers from env and route requests via `base_url + "/v1/openai/v1"`.
>     - Add `OpenAIAIGatewayProvider` to build/configure the gateway client for `OpenAIChatModel`.
>   - **Model Integration**:
>     - Update `ModelManager` to initialize models with `provider: "gateway"` via `initialize_ai_gateway_model()`.
> - **Docs**:
>   - Add `docs/COOKBOOK.md` with steps to configure env vars and YAML `model_config` for connecting to an AI Gateway.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94e46b24861d191f5ce68dfaafb24d4da3b65399. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->