### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS
+
+See `README.md`, `CONTRIBUTING_GUIDE.md`, and `docs/USER_GUIDE.md` for the full product overview.
+
+## Cursor Cloud specific instructions
+
+Opus Agents is a Python (uv) agent framework + CLI. It is a uv workspace with members
+`opus_agent_base` and `opus_todo_agent`. Python is provided by `uv` (requires >= 3.12).
+The startup update script runs `uv sync --extra dev`, so deps (incl. ruff/black/mypy/pytest)
+are already installed.
+
+Non-obvious caveats:
+
+- **The `opus_agent_base` wheel is consumed by the sibling `codd_query_engine` repo.** The startup
+  update script builds it into `opus_agent_base/dist/` with
+  `uv build opus_agent_base --out-dir opus_agent_base/dist`. That `dist/` dir is gitignored; rebuild
+  it if it goes missing. Build with `uv build` (not `python -m build`, which needs `python3.12-venv`
+  / `ensurepip` that is not installed).
+- **The CLI requires a config file before it will start.** Create it once with
+  `mkdir -p ~/.opusai && cp opus-config.sample.yml ~/.opusai/opus-config.yml` (or run
+  `opus-agents --admin` then `/config init`). This lives in `$HOME`, not the repo.
+- **Agent modes need LLM credentials.** `--agent` / `--todo-agent` / `--sde-agent` make real LLM
+  calls and require `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`. The `--admin` mode (config/status slash
+  commands) works without keys and is the easiest smoke test.
+
+Run the CLI: `uv run opus-agents --help` (or `--admin`).
+Lint/format/types: `uv run ruff check`, `uv run black .`, `uv run mypy` (repo has pre-existing
+ruff findings). Tests: `uv run pytest` (no test files exist yet, so 0 are collected).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing non-obvious setup/run notes discovered while setting up the development environment for this repo in Cursor Cloud.

Key caveats documented:
- `uv sync --extra dev` installs everything (Python is provided by `uv`).
- The `opus_agent_base` wheel is consumed by the sibling `codd_query_engine` repo; build it with `uv build opus_agent_base --out-dir opus_agent_base/dist` (use `uv build`, not `python -m build`, which needs `python3.12-venv`/`ensurepip`).
- The CLI requires a config file at `~/.opusai/opus-config.yml` (copy from `opus-config.sample.yml`) before it will start.
- Agent modes need `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`; `--admin` mode works without keys.

## Verification

`uv sync --extra dev`, built the `opus_agent_base` wheel, ran `uv run ruff check` (pre-existing findings), `uv run pytest` (no test files yet), and exercised the CLI: `uv run opus-agents --admin` → loaded config and ran `/status` / `/config get` slash commands successfully.

No application/source code was changed — documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dff9ad4a-a210-4829-bda4-2e1c19361dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dff9ad4a-a210-4829-bda4-2e1c19361dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

