### PR TITLE
Add SubagentAsTool wrapper for agent-to-subagent calls

### DIFF
--- a/CONTRIBUTING_GUIDE.md
+++ b/CONTRIBUTING_GUIDE.md
@@ -28,8 +28,7 @@ Tech stacks used are:
 
 **Adding Sub-Agents:**
 
-Check zoom_tools.py and zoom_assistant.py in opus_todo_agent for patterns to add Sub-Agent with its own model, prompts etc.
-Similar patterns are used in multiple places
+Use `SubagentAsTool` from `opus_agent_base.tools.subagent_as_tool` to wrap a PydanticAI subagent and call it from a parent agent tool. See existing usages in `zoom_meeting_assistant.py`, `slack_assistant.py`, and `obsidian_rag.py`.
 
 **Adding New Agent:**
 

--- a/opus_agent_base/src/opus_agent_base/tools/__init__.py
+++ b/opus_agent_base/src/opus_agent_base/tools/__init__.py
@@ -1,1 +1,5 @@
 """Tools and MCP server management."""
+
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
+
+__all__ = ["SubagentAsTool"]

--- a/opus_agent_base/src/opus_agent_base/tools/subagent_as_tool.py
+++ b/opus_agent_base/src/opus_agent_base/tools/subagent_as_tool.py
@@ -17,9 +17,16 @@ class SubagentAsTool:
     and returning ``response.output`` to the parent agent.
     """
 
-    def __init__(self, subagent: Agent, *, name: str = "subagent"):
+    def __init__(
+        self,
+        subagent: Agent,
+        *,
+        name: str = "subagent",
+        tool_name: str | None = None,
+    ):
         self.subagent = subagent
         self.name = name
+        self.tool_name = tool_name or f"run_{name}"
 
     @classmethod
     def from_instructions(
@@ -28,10 +35,11 @@ class SubagentAsTool:
         name: str,
         instructions: str,
         model: Any,
+        tool_name: str | None = None,
         **agent_kwargs: Any,
     ) -> "SubagentAsTool":
         subagent = Agent(instructions=instructions, model=model, **agent_kwargs)
-        return cls(subagent, name=name)
+        return cls(subagent, name=name, tool_name=tool_name)
 
     @classmethod
     def from_managers(
@@ -43,6 +51,7 @@ class SubagentAsTool:
         instructions_manager: Any,
         model_manager: Any,
         use_local_model_config_key: str | None = None,
+        tool_name: str | None = None,
         **agent_kwargs: Any,
     ) -> "SubagentAsTool":
         if use_local_model_config_key and config_manager.get_setting(
@@ -56,6 +65,7 @@ class SubagentAsTool:
             name=name,
             instructions=instructions,
             model=model,
+            tool_name=tool_name,
             **agent_kwargs,
         )
 
@@ -84,23 +94,25 @@ class SubagentAsTool:
         parent_agent: Agent,
         *,
         sync: bool = False,
+        tool_name: str | None = None,
     ) -> None:
         """
         Register a single ``prompt`` parameter tool on ``parent_agent`` that
         forwards the prompt to this subagent.
         """
         subagent_tool = self
+        registered_tool_name = tool_name or self.tool_name
 
         if sync:
 
-            @parent_agent.tool
+            @parent_agent.tool(name=registered_tool_name)
             def run_subagent(ctx: RunContext[Any], prompt: str) -> str:
                 """Run a subagent with the given prompt and return its response."""
                 return subagent_tool.run_sync(prompt)
 
         else:
 
-            @parent_agent.tool
+            @parent_agent.tool(name=registered_tool_name)
             async def run_subagent(ctx: RunContext[Any], prompt: str) -> str:
                 """Run a subagent with the given prompt and return its response."""
                 return await subagent_tool.run(prompt)

--- a/opus_agent_base/src/opus_agent_base/tools/subagent_as_tool.py
+++ b/opus_agent_base/src/opus_agent_base/tools/subagent_as_tool.py
@@ -1,0 +1,106 @@
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pydantic_ai import Agent, RunContext
+
+logger = logging.getLogger(__name__)
+
+PromptBuilder = Callable[..., str | Awaitable[str]]
+
+
+class SubagentAsTool:
+    """
+    Wrap a PydanticAI Agent so a parent agent can invoke it as a tool.
+
+    Simplifies the common flow of creating a subagent, building a prompt,
+    and returning ``response.output`` to the parent agent.
+    """
+
+    def __init__(self, subagent: Agent, *, name: str = "subagent"):
+        self.subagent = subagent
+        self.name = name
+
+    @classmethod
+    def from_instructions(
+        cls,
+        *,
+        name: str,
+        instructions: str,
+        model: Any,
+        **agent_kwargs: Any,
+    ) -> "SubagentAsTool":
+        subagent = Agent(instructions=instructions, model=model, **agent_kwargs)
+        return cls(subagent, name=name)
+
+    @classmethod
+    def from_managers(
+        cls,
+        *,
+        name: str,
+        instructions_key: str,
+        config_manager: Any,
+        instructions_manager: Any,
+        model_manager: Any,
+        use_local_model_config_key: str | None = None,
+        **agent_kwargs: Any,
+    ) -> "SubagentAsTool":
+        if use_local_model_config_key and config_manager.get_setting(
+            use_local_model_config_key, False
+        ):
+            model = model_manager.get_local_model()
+        else:
+            model = model_manager.get_model()
+        instructions = instructions_manager.get(instructions_key)
+        return cls.from_instructions(
+            name=name,
+            instructions=instructions,
+            model=model,
+            **agent_kwargs,
+        )
+
+    async def run(self, prompt: str, **run_kwargs: Any) -> str:
+        logger.info(f"Calling SubAgent [{self.name}]")
+        logger.debug(f"SubAgent [{self.name}] prompt: {prompt}")
+        response = await self.subagent.run(prompt, **run_kwargs)
+        output = response.output
+        logger.info(f"SubAgent [{self.name}] response: {len(output)} chars")
+        return output
+
+    def run_sync(self, prompt: str, **run_kwargs: Any) -> str:
+        logger.info(f"Calling SubAgent [{self.name}]")
+        logger.debug(f"SubAgent [{self.name}] prompt: {prompt}")
+        response = self.subagent.run_sync(prompt, **run_kwargs)
+        output = response.output
+        logger.info(f"SubAgent [{self.name}] response: {len(output)} chars")
+        return output
+
+    @staticmethod
+    def format_prompt(template: str, **kwargs: Any) -> str:
+        return template.format(**kwargs)
+
+    def register_prompt_tool(
+        self,
+        parent_agent: Agent,
+        *,
+        sync: bool = False,
+    ) -> None:
+        """
+        Register a single ``prompt`` parameter tool on ``parent_agent`` that
+        forwards the prompt to this subagent.
+        """
+        subagent_tool = self
+
+        if sync:
+
+            @parent_agent.tool
+            def run_subagent(ctx: RunContext[Any], prompt: str) -> str:
+                """Run a subagent with the given prompt and return its response."""
+                return subagent_tool.run_sync(prompt)
+
+        else:
+
+            @parent_agent.tool
+            async def run_subagent(ctx: RunContext[Any], prompt: str) -> str:
+                """Run a subagent with the given prompt and return its response."""
+                return await subagent_tool.run(prompt)

--- a/opus_agent_base/tests/conftest.py
+++ b/opus_agent_base/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "integration: end-to-end tests using pydantic_ai TestModel agents",
+    )

--- a/opus_agent_base/tests/test_subagent_as_tool.py
+++ b/opus_agent_base/tests/test_subagent_as_tool.py
@@ -1,0 +1,109 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
+
+
+class TestSubagentAsToolUnit:
+    def test_format_prompt_example(self):
+        """Example: build a subagent prompt from retrieved context."""
+        prompt = SubagentAsTool.format_prompt(
+            "Question: {question}\nNotes:\n{context}",
+            question="What should we ship this week?",
+            context="- SubagentAsTool wrapper\n- Unit tests",
+        )
+        assert "What should we ship this week?" in prompt
+        assert "SubagentAsTool wrapper" in prompt
+
+    def test_from_instructions_creates_named_wrapper(self):
+        """Example: create a specialist subagent from instructions + test model."""
+        tool = SubagentAsTool.from_instructions(
+            name="release_notes_writer",
+            instructions="Write concise release notes.",
+            model=TestModel(custom_output_text="Added SubagentAsTool."),
+        )
+
+        assert tool.name == "release_notes_writer"
+        assert tool.subagent is not None
+
+    def test_run_sync_returns_subagent_output(self):
+        response = MagicMock()
+        response.output = "subagent answer"
+        subagent = MagicMock()
+        subagent.run_sync.return_value = response
+
+        tool = SubagentAsTool(subagent, name="test_subagent")
+        result = tool.run_sync("hello")
+
+        assert result == "subagent answer"
+        subagent.run_sync.assert_called_once_with("hello")
+
+    @pytest.mark.asyncio
+    async def test_run_returns_subagent_output(self):
+        response = MagicMock()
+        response.output = "async answer"
+        subagent = MagicMock()
+        subagent.run = AsyncMock(return_value=response)
+
+        tool = SubagentAsTool(subagent, name="test_subagent")
+        result = await tool.run("hello")
+
+        assert result == "async answer"
+        subagent.run.assert_awaited_once_with("hello")
+
+    def test_from_managers_uses_local_model_when_configured(self, monkeypatch):
+        created_agents = []
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                created_agents.append(kwargs)
+
+        monkeypatch.setattr(
+            "opus_agent_base.tools.subagent_as_tool.Agent",
+            FakeAgent,
+        )
+
+        config_manager = MagicMock()
+        config_manager.get_setting.return_value = True
+        instructions_manager = MagicMock()
+        instructions_manager.get.return_value = "You are a helper."
+        model_manager = MagicMock()
+        model_manager.get_local_model.return_value = "local-model"
+        model_manager.get_model.return_value = "cloud-model"
+
+        tool = SubagentAsTool.from_managers(
+            name="helper",
+            instructions_key="helper_instructions",
+            config_manager=config_manager,
+            instructions_manager=instructions_manager,
+            model_manager=model_manager,
+            use_local_model_config_key="helper.use_local_model",
+        )
+
+        assert tool.name == "helper"
+        assert created_agents == [
+            {
+                "instructions": "You are a helper.",
+                "model": "local-model",
+            }
+        ]
+        model_manager.get_local_model.assert_called_once_with()
+        model_manager.get_model.assert_not_called()
+        instructions_manager.get.assert_called_once_with("helper_instructions")
+
+    def test_register_prompt_tool_adds_tool_to_parent_agent(self):
+        subagent = Agent(
+            model=TestModel(custom_output_text="done"),
+            instructions="You are a helper.",
+        )
+        parent = Agent(
+            model=TestModel(),
+            instructions="You delegate to helpers.",
+        )
+
+        SubagentAsTool(subagent, name="helper").register_prompt_tool(parent)
+
+        assert "run_subagent" in parent._function_toolset.tools

--- a/opus_agent_base/tests/test_subagent_as_tool.py
+++ b/opus_agent_base/tests/test_subagent_as_tool.py
@@ -1,10 +1,9 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
-
-from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 
 
 class TestSubagentAsToolUnit:
@@ -27,7 +26,19 @@ class TestSubagentAsToolUnit:
         )
 
         assert tool.name == "release_notes_writer"
+        assert tool.tool_name == "run_release_notes_writer"
         assert tool.subagent is not None
+
+    def test_from_instructions_allows_explicit_tool_name(self):
+        """Example: expose a short tool name for the parent agent."""
+        tool = SubagentAsTool.from_instructions(
+            name="release_notes_writer",
+            tool_name="draft_release_notes",
+            instructions="Write concise release notes.",
+            model=TestModel(custom_output_text="Added SubagentAsTool."),
+        )
+
+        assert tool.tool_name == "draft_release_notes"
 
     def test_run_sync_returns_subagent_output(self):
         response = MagicMock()
@@ -106,4 +117,21 @@ class TestSubagentAsToolUnit:
 
         SubagentAsTool(subagent, name="helper").register_prompt_tool(parent)
 
-        assert "run_subagent" in parent._function_toolset.tools
+        assert "run_helper" in parent._function_toolset.tools
+
+    def test_register_prompt_tool_allows_tool_name_override(self):
+        subagent = Agent(
+            model=TestModel(custom_output_text="done"),
+            instructions="You are a helper.",
+        )
+        parent = Agent(
+            model=TestModel(),
+            instructions="You delegate to helpers.",
+        )
+
+        SubagentAsTool(subagent, name="helper").register_prompt_tool(
+            parent,
+            tool_name="ask_helper",
+        )
+
+        assert "ask_helper" in parent._function_toolset.tools

--- a/opus_agent_base/tests/test_subagent_as_tool_integration.py
+++ b/opus_agent_base/tests/test_subagent_as_tool_integration.py
@@ -1,8 +1,7 @@
 import pytest
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.models.test import TestModel
-
-from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 
 
 @pytest.mark.integration
@@ -33,7 +32,30 @@ class TestSubagentAsToolIntegration:
         result = await parent.run("Research the latest updates on SubagentAsTool.")
 
         assert "Finding A" in result.output
-        assert "run_subagent" in result.output or "Finding B" in result.output
+        assert "run_research_assistant" in result.output or "Finding B" in result.output
+
+    def test_parent_can_register_multiple_named_subagent_tools(self):
+        """Example: one parent exposes separate specialist subagents as tools."""
+        summarizer = SubagentAsTool.from_instructions(
+            name="summarizer",
+            instructions="Summarize long content.",
+            model=TestModel(custom_output_text="Short summary."),
+        )
+        classifier = SubagentAsTool.from_instructions(
+            name="classifier",
+            instructions="Classify incoming content.",
+            model=TestModel(custom_output_text="bug_report"),
+        )
+        parent = Agent(
+            model=TestModel(),
+            instructions="Choose the right specialist for each request.",
+        )
+
+        summarizer.register_prompt_tool(parent)
+        classifier.register_prompt_tool(parent)
+
+        assert "run_summarizer" in parent._function_toolset.tools
+        assert "run_classifier" in parent._function_toolset.tools
 
     @pytest.mark.asyncio
     async def test_custom_tool_pattern_with_context_prompt(self):
@@ -95,7 +117,7 @@ class TestSubagentAsToolIntegration:
         classifier.register_prompt_tool(parent, sync=True)
 
         tool_names = list(parent._function_toolset.tools.keys())
-        assert "run_subagent" in tool_names
+        assert "run_priority_classifier" in tool_names
 
         output = parent.run_sync("Classify: write docs for SubagentAsTool.")
         assert output.output

--- a/opus_agent_base/tests/test_subagent_as_tool_integration.py
+++ b/opus_agent_base/tests/test_subagent_as_tool_integration.py
@@ -1,0 +1,101 @@
+import pytest
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.test import TestModel
+
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
+
+
+@pytest.mark.integration
+class TestSubagentAsToolIntegration:
+    @pytest.mark.asyncio
+    async def test_parent_agent_calls_subagent_via_register_prompt_tool(self):
+        """
+        Example: a parent coordinator delegates open-ended work to a specialist
+        subagent through a prompt-only tool registered by SubagentAsTool.
+        """
+        research_subagent = SubagentAsTool.from_instructions(
+            name="research_assistant",
+            instructions="Summarize research findings as concise bullet points.",
+            model=TestModel(
+                custom_output_text="- Finding A\n- Finding B\n- Finding C",
+            ),
+        )
+
+        parent = Agent(
+            model=TestModel(),
+            instructions=(
+                "You coordinate tasks. When the user asks for research, "
+                "call the research assistant tool with a focused prompt."
+            ),
+        )
+        research_subagent.register_prompt_tool(parent)
+
+        result = await parent.run("Research the latest updates on SubagentAsTool.")
+
+        assert "Finding A" in result.output
+        assert "run_subagent" in result.output or "Finding B" in result.output
+
+    @pytest.mark.asyncio
+    async def test_custom_tool_pattern_with_context_prompt(self):
+        """
+        Example: parent tool prepares context (like meeting transcripts or notes)
+        and forwards a formatted prompt to the subagent.
+        """
+        document = (
+            "Alice: We should ship SubagentAsTool this week.\n"
+            "Bob: Add unit and integration tests before merging."
+        )
+
+        summarizer = SubagentAsTool.from_instructions(
+            name="meeting_summarizer",
+            instructions="Summarize meeting transcripts.",
+            model=TestModel(custom_output_text="Ship SubagentAsTool with tests."),
+        )
+
+        parent = Agent(
+            model=TestModel(),
+            instructions="You help users understand meeting transcripts.",
+        )
+
+        @parent.tool
+        async def summarize_meeting(ctx: RunContext[None], meeting_id: str) -> str:
+            """Summarize a meeting transcript by meeting id."""
+            prompt = SubagentAsTool.format_prompt(
+                "Meeting id: {meeting_id}\nTranscript:\n{transcript}\n"
+                "Provide a one-line summary.",
+                meeting_id=meeting_id,
+                transcript=document,
+            )
+            return await summarizer.run(prompt)
+
+        tool = parent._function_toolset.tools["summarize_meeting"]
+        ctx = RunContext(
+            deps=None,
+            model=parent.model,
+            usage=None,
+            prompt=None,
+            messages=[],
+        )
+        summary = await tool.function(ctx, meeting_id="M-42")
+
+        assert summary == "Ship SubagentAsTool with tests."
+
+    def test_sync_subagent_tool_registration(self):
+        """Example: register a synchronous subagent tool for blocking workflows."""
+        classifier = SubagentAsTool.from_instructions(
+            name="priority_classifier",
+            instructions="Classify task priority.",
+            model=TestModel(custom_output_text="P2"),
+        )
+
+        parent = Agent(
+            model=TestModel(),
+            instructions="Classify incoming tasks.",
+        )
+        classifier.register_prompt_tool(parent, sync=True)
+
+        tool_names = list(parent._function_toolset.tools.keys())
+        assert "run_subagent" in tool_names
+
+        output = parent.run_sync("Classify: write docs for SubagentAsTool.")
+        assert output.output

--- a/opus_todo_agent/src/opus_todo_agent/custom_tools/meeting_transcript/loom_meeting_assistant.py
+++ b/opus_todo_agent/src/opus_todo_agent/custom_tools/meeting_transcript/loom_meeting_assistant.py
@@ -16,7 +16,9 @@ class LoomMeetingAssistant:
 
     LOOM_TRANSCRIPT_FILE_EXTENSION = "srt"
 
-    def __init__(self, config_manager=None, instructions_manager=None, model_manager=None):
+    def __init__(
+        self, config_manager=None, instructions_manager=None, model_manager=None
+    ):
         self.config_manager = config_manager
         self.loom_storage_dir = config_manager.get_setting(
             "meeting_transcript.loom.storage_dir"
@@ -35,7 +37,8 @@ class LoomMeetingAssistant:
 
     def ask_loom_transcript(self, meeting_id: str, query: str) -> str:
         logger.info(
-            f"Calling SubAgent to Ask question about meeting transcript: {query} for meeting id: {meeting_id}"
+            "Calling SubAgent to Ask question about meeting transcript: "
+            f"{query} for meeting id: {meeting_id}"
         )
         transcript_file = os.path.join(
             self.loom_storage_dir,
@@ -56,7 +59,9 @@ class LoomMeetingAssistant:
             transcript, max_size
         )
         # generate context for the agent
-        prompt_template = self.instructions_manager.get("loom_meeting_assistant_prompt_template")
+        prompt_template = self.instructions_manager.get(
+            "loom_meeting_assistant_prompt_template"
+        )
         prompt = SubagentAsTool.format_prompt(
             prompt_template, context=transcript, question=query
         )

--- a/opus_todo_agent/src/opus_todo_agent/custom_tools/meeting_transcript/loom_meeting_assistant.py
+++ b/opus_todo_agent/src/opus_todo_agent/custom_tools/meeting_transcript/loom_meeting_assistant.py
@@ -1,8 +1,7 @@
 import logging
 import os
 
-from pydantic_ai import Agent
-
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 from opus_todo_agent.helper.meeting_transcript.meeting_assistant_helper import (
     MeetingAssistantHelper,
 )
@@ -25,18 +24,13 @@ class LoomMeetingAssistant:
         self.instructions_manager = instructions_manager
         self.model_manager = model_manager
         self.meeting_assistant_helper = MeetingAssistantHelper()
-        self._init_agent()
-
-    def _init_agent(self):
-        if self.config_manager.get_setting(
-            "meeting_transcript.loom.use_local_model", False
-        ):
-            model = self.model_manager.get_local_model()
-        else:
-            model = self.model_manager.get_model()
-        self.agent = Agent(
-            instructions=self.instructions_manager.get("loom_meeting_assistant_instructions"),
-            model=model,
+        self.subagent = SubagentAsTool.from_managers(
+            name="loom_meeting_assistant",
+            instructions_key="loom_meeting_assistant_instructions",
+            config_manager=config_manager,
+            instructions_manager=instructions_manager,
+            model_manager=model_manager,
+            use_local_model_config_key="meeting_transcript.loom.use_local_model",
         )
 
     def ask_loom_transcript(self, meeting_id: str, query: str) -> str:
@@ -63,7 +57,7 @@ class LoomMeetingAssistant:
         )
         # generate context for the agent
         prompt_template = self.instructions_manager.get("loom_meeting_assistant_prompt_template")
-        response = self.meeting_assistant_helper.ask_transcript(
-            self.agent, prompt_template, transcript, query
+        prompt = SubagentAsTool.format_prompt(
+            prompt_template, context=transcript, question=query
         )
-        return response
+        return self.subagent.run_sync(prompt)

--- a/opus_todo_agent/src/opus_todo_agent/custom_tools/meeting_transcript/zoom_meeting_assistant.py
+++ b/opus_todo_agent/src/opus_todo_agent/custom_tools/meeting_transcript/zoom_meeting_assistant.py
@@ -1,8 +1,7 @@
 import logging
 import os
 
-from pydantic_ai import Agent
-
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 from opus_todo_agent.helper.meeting_transcript.meeting_assistant_helper import (
     MeetingAssistantHelper,
 )
@@ -25,18 +24,13 @@ class ZoomMeetingAssistant:
         self.instructions_manager = instructions_manager
         self.model_manager = model_manager
         self.meeting_assistant_helper = MeetingAssistantHelper()
-        self._init_agent()
-
-    def _init_agent(self):
-        if self.config_manager.get_setting(
-            "meeting_transcript.zoom.use_local_model", False
-        ):
-            model = self.model_manager.get_local_model()
-        else:
-            model = self.model_manager.get_model()
-        self.agent = Agent(
-            instructions=self.instructions_manager.get("zoom_meeting_assistant_instructions"),
-            model=model,
+        self.subagent = SubagentAsTool.from_managers(
+            name="zoom_meeting_assistant",
+            instructions_key="zoom_meeting_assistant_instructions",
+            config_manager=config_manager,
+            instructions_manager=instructions_manager,
+            model_manager=model_manager,
+            use_local_model_config_key="meeting_transcript.zoom.use_local_model",
         )
 
     def ask_zoom_transcript(self, meeting_id: str, query: str) -> str:
@@ -65,7 +59,7 @@ class ZoomMeetingAssistant:
         )
         # generate context for the agent
         prompt_template = self.instructions_manager.get("zoom_meeting_assistant_prompt_template")
-        response = self.meeting_assistant_helper.ask_transcript(
-            self.agent, prompt_template, transcript, query
+        prompt = SubagentAsTool.format_prompt(
+            prompt_template, context=transcript, question=query
         )
-        return response
+        return self.subagent.run_sync(prompt)

--- a/opus_todo_agent/src/opus_todo_agent/custom_tools/meeting_transcript/zoom_meeting_assistant.py
+++ b/opus_todo_agent/src/opus_todo_agent/custom_tools/meeting_transcript/zoom_meeting_assistant.py
@@ -58,7 +58,9 @@ class ZoomMeetingAssistant:
             transcript, max_size
         )
         # generate context for the agent
-        prompt_template = self.instructions_manager.get("zoom_meeting_assistant_prompt_template")
+        prompt_template = self.instructions_manager.get(
+            "zoom_meeting_assistant_prompt_template"
+        )
         prompt = SubagentAsTool.format_prompt(
             prompt_template, context=transcript, question=query
         )

--- a/opus_todo_agent/src/opus_todo_agent/custom_tools/notes/obsidian_rag.py
+++ b/opus_todo_agent/src/opus_todo_agent/custom_tools/notes/obsidian_rag.py
@@ -1,7 +1,7 @@
-import chromadb
 import logging
 import os
 
+import chromadb
 from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ class ObsidianRAG:
         self.instructions_manager = instructions_manager
         self.model_manager = model_manager
         vault_config_list = self.config_manager.get_setting(
-            f"notes.obsidian.vault_configurations"
+            "notes.obsidian.vault_configurations"
         )
         self.vault_config = next(
             (

--- a/opus_todo_agent/src/opus_todo_agent/custom_tools/notes/obsidian_rag.py
+++ b/opus_todo_agent/src/opus_todo_agent/custom_tools/notes/obsidian_rag.py
@@ -1,10 +1,10 @@
 import chromadb
-from pydantic_ai import Agent
 import logging
+import os
+
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 
 logger = logging.getLogger(__name__)
-
-import os
 
 # Disable tokenizers parallelism to avoid warnings
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -38,7 +38,13 @@ class ObsidianRAG:
         ), f"Vault config not found for {self.obsidian_vault_name}"
         logger.info(f"Vault config: {self.vault_config}")
         self._init_vector_db()
-        self._init_agent()
+        self.subagent = SubagentAsTool.from_managers(
+            name="obsidian_notes",
+            instructions_key="obsidian_notes_instructions",
+            config_manager=self.config_manager,
+            instructions_manager=self.instructions_manager,
+            model_manager=self.model_manager,
+        )
 
     def _init_vector_db(self):
         vector_db_path = self.vault_config.get("vector_db_path")
@@ -47,12 +53,6 @@ class ObsidianRAG:
         self.client = chromadb.PersistentClient(path=vector_db_path)
         # init collection
         self.collection = self.client.get_or_create_collection(vector_db_collection)
-
-    def _init_agent(self):
-        self.agent = Agent(
-            instructions=self.instructions_manager.get("obsidian_notes_instructions"),
-            model=self.model_manager.get_model(),
-        )
 
     def retrieve_notes(self, query: str) -> str:
         """
@@ -97,6 +97,7 @@ class ObsidianRAG:
         prompt_template = self.instructions_manager.get(
             "obsidian_notes_prompt_template"
         )
-        prompt = prompt_template.format(context=notes, question=query)
-        response = self.agent.run_sync(prompt)
-        return response.output
+        prompt = SubagentAsTool.format_prompt(
+            prompt_template, context=notes, question=query
+        )
+        return self.subagent.run_sync(prompt)

--- a/opus_todo_agent/src/opus_todo_agent/helper/meeting_transcript/meeting_assistant_helper.py
+++ b/opus_todo_agent/src/opus_todo_agent/helper/meeting_transcript/meeting_assistant_helper.py
@@ -3,6 +3,8 @@ import logging
 import tiktoken
 from pydantic_ai import Agent
 
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
+
 logger = logging.getLogger(__name__)
 
 class MeetingAssistantHelper:
@@ -32,6 +34,7 @@ class MeetingAssistantHelper:
         return transcript
 
     def ask_transcript(self, agent: Agent, prompt_template: str, transcript: str, query: str) -> str:
-        prompt = prompt_template.format(context=transcript, question=query)
-        response = agent.run_sync(prompt)
-        return response.output
+        prompt = SubagentAsTool.format_prompt(
+            prompt_template, context=transcript, question=query
+        )
+        return SubagentAsTool(agent, name="meeting_assistant").run_sync(prompt)

--- a/opus_todo_agent/src/opus_todo_agent/helper/meeting_transcript/meeting_assistant_helper.py
+++ b/opus_todo_agent/src/opus_todo_agent/helper/meeting_transcript/meeting_assistant_helper.py
@@ -1,11 +1,11 @@
 import logging
 
 import tiktoken
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 from pydantic_ai import Agent
 
-from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
-
 logger = logging.getLogger(__name__)
+
 
 class MeetingAssistantHelper:
     """
@@ -17,23 +17,30 @@ class MeetingAssistantHelper:
         pass
 
     def read_transcript_from_file(self, transcript_path: str) -> str:
-        with open(transcript_path, "r") as f:
+        with open(transcript_path) as f:
             transcript = f.read()
         return transcript
 
     def preprocess_transcript(self, transcript: str, max_size: int) -> str:
         encoding = tiktoken.get_encoding("cl100k_base")
         tokens = encoding.encode(transcript)
-        logger.info(f"Retrieved transcript: {len(transcript)} chars, {len(tokens)} tokens")
+        logger.info(
+            f"Retrieved transcript: {len(transcript)} chars, {len(tokens)} tokens"
+        )
         if max_size > 0:
             # Truncate by tokens
             if len(tokens) > max_size:
                 truncated_tokens = tokens[:max_size]
                 transcript = encoding.decode(truncated_tokens)
-                logger.info(f"Truncated transcript: {len(transcript)} chars, {len(truncated_tokens)} tokens")
+                logger.info(
+                    "Truncated transcript: "
+                    f"{len(transcript)} chars, {len(truncated_tokens)} tokens"
+                )
         return transcript
 
-    def ask_transcript(self, agent: Agent, prompt_template: str, transcript: str, query: str) -> str:
+    def ask_transcript(
+        self, agent: Agent, prompt_template: str, transcript: str, query: str
+    ) -> str:
         prompt = SubagentAsTool.format_prompt(
             prompt_template, context=transcript, question=query
         )

--- a/opus_todo_agent/src/opus_todo_agent/higher_order_tools/chat/slack_assistant.py
+++ b/opus_todo_agent/src/opus_todo_agent/higher_order_tools/chat/slack_assistant.py
@@ -1,7 +1,6 @@
 import logging
 
-from pydantic_ai import Agent
-
+from opus_agent_base.tools.subagent_as_tool import SubagentAsTool
 from opus_todo_agent.helper.chat.slack_helper import SlackHelper
 
 logger = logging.getLogger(__name__)
@@ -17,16 +16,13 @@ class SlackAssistant:
         self.instructions_manager = instructions_manager
         self.model_manager = model_manager
         self.slack_helper = SlackHelper()
-        self._init_agent()
-
-    def _init_agent(self):
-        if self.config_manager.get_setting("chat.slack.use_local_model", False):
-            model = self.model_manager.get_local_model()
-        else:
-            model = self.model_manager.get_model()
-        self.agent = Agent(
-            instructions=self.instructions_manager.get("slack_assistant_instructions"),
-            model=model,
+        self.subagent = SubagentAsTool.from_managers(
+            name="slack_assistant",
+            instructions_key="slack_assistant_instructions",
+            config_manager=config_manager,
+            instructions_manager=instructions_manager,
+            model_manager=model_manager,
+            use_local_model_config_key="chat.slack.use_local_model",
         )
 
     async def fetch_and_summarize_messages_from_channels(
@@ -101,7 +97,8 @@ class SlackAssistant:
 
         # Generate prompt
         prompt_template = self.instructions_manager.get("slack_assistant_prompt_template")
-        prompt = prompt_template.format(
+        prompt = SubagentAsTool.format_prompt(
+            prompt_template,
             channel_scope_type=channel_scope_type,
             channel_scope_name=channel_scope_name,
             time_limit=time_limit,
@@ -111,6 +108,4 @@ class SlackAssistant:
 
         # Call agent to summarize
         logger.debug(f"Calling SubAgent with prompt: {prompt}")
-        response = await self.agent.run(prompt)
-        logger.info(f"Received summary from model: {len(response.output)} chars")
-        return response.output
+        return await self.subagent.run(prompt)

--- a/opus_todo_agent/src/opus_todo_agent/higher_order_tools/chat/slack_assistant.py
+++ b/opus_todo_agent/src/opus_todo_agent/higher_order_tools/chat/slack_assistant.py
@@ -41,13 +41,15 @@ class SlackAssistant:
             channels: List of channel names
             channel_scope_type: Type of scope (team/project/channel)
             channel_scope_name: Name of the team/project or channel
-            time_limit: Time period for conversation history (e.g., "1d", "1w", "5d", "4w")
+            time_limit: Time period for conversation history
+                (e.g., "1d", "1w", "5d", "4w")
 
         Returns:
             Summarized messages grouped by channel
         """
         logger.info(
-            f"Calling SubAgent to summarize Slack messages for {channel_scope_type}: {channel_scope_name}, time_limit: {time_limit}"
+            "Calling SubAgent to summarize Slack messages for "
+            f"{channel_scope_type}: {channel_scope_name}, time_limit: {time_limit}"
         )
         # resolve channel scope and name to channel ids
         if channel_scope_type == "team":
@@ -61,13 +63,13 @@ class SlackAssistant:
         elif channel_scope_type == "channel":
             channels = [channel_scope_name]
         else:
-            raise ValueError(
-                f"Invalid channel scope type: {channel_scope_type}"
-            )
+            raise ValueError(f"Invalid channel scope type: {channel_scope_type}")
 
         channel_ids = self.slack_helper.get_channel_ids(channels)
         logging.info(
-            f"[SubAgent] Fetched channels for {channel_scope_type} : {channel_scope_name} as #{channels} with ids: {channel_ids}"
+            "[SubAgent] Fetched channels for "
+            f"{channel_scope_type} : {channel_scope_name} as #{channels} "
+            f"with ids: {channel_ids}"
         )
 
         # Fetch conversation history
@@ -85,7 +87,7 @@ class SlackAssistant:
             f"Retrieved conversation history: {len(str(conversation_history))} chars"
         )
 
-        # FIXME: if conversation history is too large, summarize per channel and truncate it if required
+        # FIXME: summarize per channel if the conversation history is too large.
 
         # Build channel ID to name mapping for the specific channels
         channel_mapping = "\n".join(
@@ -96,7 +98,9 @@ class SlackAssistant:
         )
 
         # Generate prompt
-        prompt_template = self.instructions_manager.get("slack_assistant_prompt_template")
+        prompt_template = self.instructions_manager.get(
+            "slack_assistant_prompt_template"
+        )
         prompt = SubagentAsTool.format_prompt(
             prompt_template,
             channel_scope_type=channel_scope_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"
+markers = [
+    "integration: end-to-end tests using pydantic_ai TestModel agents",
+]
 
 # UV workspace configuration
 [tool.uv.workspace]


### PR DESCRIPTION
## Summary
- Add `SubagentAsTool` to wrap PydanticAI agents for sync/async subagent calls from parent-agent tools.
- Refactor existing Slack, notes, Zoom, and Loom assistant flows to use the wrapper instead of one-off subagent setup.
- Add unit and integration examples, including named tool registration for multiple specialist subagents.

## Test plan
- `uv run pytest opus_agent_base/tests/test_subagent_as_tool.py opus_agent_base/tests/test_subagent_as_tool_integration.py`
- `uv run pytest`
- `uv run ruff check <touched files>`

Closes #24